### PR TITLE
add stimulus and article content recovery in client through ajax call

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
     msgpack (1.4.2)
     netrc (0.11.0)
     nio4r (2.5.7)
-    nokogiri (1.11.1)
+    nokogiri (1.11.2)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     orm_adapter (0.5.0)
@@ -290,4 +290,4 @@ RUBY VERSION
    ruby 2.6.6p146
 
 BUNDLED WITH
-   2.2.5
+   2.1.4

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,6 +1,5 @@
 class ArticlesController < ApplicationController
-
-    skip_before_action :authenticate_user!, only: [ :create, :find_sources, :show ]
+  skip_before_action :authenticate_user!, only: [ :create, :find_sources, :show ]
 
   def create
     @article = Article.new(article_params)
@@ -18,18 +17,22 @@ class ArticlesController < ApplicationController
 
   def show
     @article = Article.find(params[:id])
+    respond_to do |format|
+      format.html # will render a view by default
+      format.json { render json: @article }
+    end
   end
 
   private
 
   # On wikipedia.com, retrieve top search result url
   def top_article_wikipedia(query)
-    parsed_query = query.split(' ').map { |word| URI.escape(word) }.join('+')
+    parsed_query = query.split.map { |word| URI.escape(word) }.join('+')
     url = "https://en.wikipedia.org/w/api.php?action=opensearch&search=#{parsed_query}"
     response = JSON.parse(RestClient.get(url))
     articles = response[1]
     urls = response[3]
-    top_article = { title: articles.first, url: urls.first, source: "wikipedia.com" }
+    { title: articles.first, url: urls.first, source: "wikipedia.com" }
   end
 
   def article_params

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,0 +1,18 @@
+// Visit The Stimulus Handbook for more details 
+// https://stimulusjs.org/handbook/introduction
+// 
+// This example controller works with specially annotated HTML like:
+//
+// <div data-controller="hello">
+//   <h1 data-target="hello.output"></h1>
+// </div>
+
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static targets = [ "output" ]
+
+  connect() {
+    this.outputTarget.textContent = 'Hello, Stimulus!'
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,0 +1,9 @@
+// Load all the controllers within this directory and all subdirectories. 
+// Controller files must be named *_controller.js.
+
+import { Application } from "stimulus"
+import { definitionsFromContext } from "stimulus/webpack-helpers"
+
+const application = Application.start()
+const context = require.context("controllers", true, /_controller\.js$/)
+application.load(definitionsFromContext(context))

--- a/app/javascript/controllers/tf_controller.js
+++ b/app/javascript/controllers/tf_controller.js
@@ -1,0 +1,22 @@
+import { Controller } from "stimulus";
+import { csrfToken } from "@rails/ujs";
+export default class extends Controller {
+  static targets = ['root', 'url']
+  connect() {
+    this.getArticle()
+  }
+
+  getArticle() {
+    const articleId = this.rootTarget.dataset.articleUid
+    const fetchUrl = this.rootTarget.dataset.url
+    fetch(fetchUrl, { headers: { accept: 'application/json' }})
+      .then(response => response.json())
+      .then((data) => {
+        console.log(data.content)
+      })
+
+    // fetch(wikiApiUrl, {
+    //   headers: {"X-CSRF-Token": csrfToken()}
+    // }).then((response) => console.log(response))
+  }
+}

--- a/app/javascript/controllers/tf_controller.js
+++ b/app/javascript/controllers/tf_controller.js
@@ -14,9 +14,5 @@ export default class extends Controller {
       .then((data) => {
         console.log(data.content)
       })
-
-    // fetch(wikiApiUrl, {
-    //   headers: {"X-CSRF-Token": csrfToken()}
-    // }).then((response) => console.log(response))
   }
 }

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -28,3 +28,5 @@ document.addEventListener('turbolinks:load', () => {
   // Call your functions here, e.g:
   // initSelect2();
 });
+
+import "controllers"

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,2 +1,4 @@
+<div data-controller="tf" data-article-uid="<%= @article.id %>" data-url="<%= article_path(@article) %>" data-tf-target="root" >
 <h1><%= @article.title %></h1>
-<p>Read the full article on <%= link_to @article.source, @article.url %></p>
+  <p>Read the full article on <%= link_to @article.source, @article.url, {'data-tf-target': 'url'} %></p>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,5 +39,6 @@ module LazyReader
 
     # Don't generate system test files.
     # config.generators.system_tests = nil
+    # Access-Control-Allow-Origin
   end
 end

--- a/db/migrate/20210315082807_add_content_to_articles.rb
+++ b/db/migrate/20210315082807_add_content_to_articles.rb
@@ -1,0 +1,5 @@
+class AddContentToArticles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :articles, :content, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_10_164111) do
+ActiveRecord::Schema.define(version: 2021_03_15_082807) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2021_03_10_164111) do
     t.string "source"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "content"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,18 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+puts "#"*30
+puts "Destroying all articles in DB..."
+Article.destroy_all
+puts "Creating Sample Article --> Daft Punk..."
+daft_punk = Article.new(
+  url: "https://en.wikipedia.org/wiki/Daft_Punk",
+  title: "Daft Punk",
+  source: "wikipedia.com",
+  content: 'Daft Punk (French pronunciation: ​[daft pœŋk]) were a French electronic music duo formed in 1993 in Paris by Guy-Manuel de Homem-Christo and Thomas Bangalter. Often considered one of the most influential acts in dance music history, they achieved popularity in the late 1990s as part of the French house movement. They also had success in the years following, combining elements of house music with funk, techno, disco, indie rock and pop. After Bangalter and Homem-Christo\'s indie rock band Darlin\' disbanded, they began experimenting with drum machines, synthesisers and the talk box. Their debut studio album Homework was released by Virgin Records in 1997 to positive reviews, backed by singles "Around the World" and "Da Funk". From 1999, they assumed robot personas with helmets, outfits and gloves for public appearances to preserve their identities; they made few media appearances.[1] They were managed from 1996 to 2008 by Pedro Winter, the head of Ed Banger Records. Daft Punk\'s second album, Discovery (2001), had further success, supported by hit singles "One More Time", "Digital Love" and "Harder, Better, Faster, Stronger". The album became the basis for an animated film, Interstella 5555, produced by Japanese animator Leiji Matsumoto. Daft Punk\'s third album, Human After All (2005), received mixed reviews, though the singles "Robot Rock" and "Technologic" achieved success in the United Kingdom. The duo directed their first film, Electroma, an avant-garde science fiction film, in 2006. They toured throughout 2006 and 2007 and released the live album Alive 2007, which won a Grammy Award for Best Electronic/Dance Album; the tour is credited for popularising dance music in North America. Daft Punk composed the score for the 2010 film Tron: Legacy. In 2013, Daft Punk left Virgin for Columbia Records and released their fourth album, Random Access Memories, to acclaim; lead single "Get Lucky" reached the top 10 in the charts of 32 countries. Random Access Memories won five Grammy Awards in 2014, including Album of the Year and Record of the Year for "Get Lucky". In 2016, Daft Punk gained their only number one on the Billboard Hot 100 with "Starboy", a collaboration with the Weeknd. Rolling Stone ranked them No. 12 on its list of the 20 Greatest Duos of All Time. They announced their split in February 2021.'
+  )
+daft_punk.save!
+puts "#"*30
+
+

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "bootstrap": "^4.6.0",
     "jquery": "^3.6.0",
     "popper.js": "^1.16.1",
+    "stimulus": "^2.0.0",
     "turbolinks": "^5.2.0"
   },
   "version": "0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -910,6 +910,30 @@
     webpack-cli "^3.3.12"
     webpack-sources "^1.4.3"
 
+"@stimulus/core@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@stimulus/core/-/core-2.0.0.tgz#140c85318d6a8a8210c0faf182223b8459348877"
+  integrity sha512-ff70GafKtzc8zQ1/cG+UvL06GcifPWovf2wBEdjLMh9xO2GOYURO3y2RYgzIGYUIBefQwyfX2CLfJdZFJrEPTw==
+  dependencies:
+    "@stimulus/mutation-observers" "^2.0.0"
+
+"@stimulus/multimap@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@stimulus/multimap/-/multimap-2.0.0.tgz#420cfa096ed6538df4a91dbd2b2842c1779952b2"
+  integrity sha512-pMBCewkZCFVB3e5mEMoyO9+9aKzHDITmf3OnPun51YWxlcPdHcwbjqm1ylK63fsoduIE+RowBpFwFqd3poEz4w==
+
+"@stimulus/mutation-observers@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@stimulus/mutation-observers/-/mutation-observers-2.0.0.tgz#3dbe37453bda47a6c795a90204ee8d77a799fb87"
+  integrity sha512-kx4VAJdPhIGBQKGIoUDC2tupEKorG3A+ckc2b1UiwInKTMAC1axOHU8ebcwhaJIxRqIrs8//4SJo9YAAOx6FEg==
+  dependencies:
+    "@stimulus/multimap" "^2.0.0"
+
+"@stimulus/webpack-helpers@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@stimulus/webpack-helpers/-/webpack-helpers-2.0.0.tgz#54296d2a2dffd4f962d2e802d99a3fdd84b8845f"
+  integrity sha512-D6tJWsAC024MwGEIKlUVYU8Ln87mlrmiwHvYAjipg+s8H4eLxUMQ3PZkWyPevfipH+oR3leuHsjYsK1gN5ViQA==
+
 "@types/glob@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
@@ -6810,6 +6834,14 @@ stdout-stream@^1.4.0:
   integrity sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==
   dependencies:
     readable-stream "^2.0.1"
+
+stimulus@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/stimulus/-/stimulus-2.0.0.tgz#713c8b91a72ef90914b90955f0e705f004403047"
+  integrity sha512-xipy7BS5TVpg4fX6S8LhrYZp7cmHGjmk09WSAiVx1gF5S5g43IWsuetfUhIk8HfHUG+4MQ9nY0FQz4dRFLs/8w==
+  dependencies:
+    "@stimulus/core" "^2.0.0"
+    "@stimulus/webpack-helpers" "^2.0.0"
 
 stream-browserify@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
 ⚠️ Nothing see on the front end

# on the back end:
- new seed with daft punk sample article
- installed stimulus (⚠️ need to 'yarn install' after pulling)
- Created the 'tf-controller' and connected it to article#show view root DOM element
- Modified article#show action to rener json when asked to through headers
- Implemented AJAX call on "connect" in the tf-controller to log the article content in console

# Next steps:
- implement scraping of wikipedia article to asynchronously fill article.content -> maybe triggered by a POST call made  from the stimulus tf-controller on the article#show view rendering ? So that the sracping is not done on creation of the article. Could also be done as a background job ! (great solution for a portfolio web app too)
- Implement TensorflowJS call in stimulus tf-controller