### PR TITLE
add tooltip with article name to source

### DIFF
--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -25,6 +25,7 @@
     padding: 15px 30px;
     color: $medium-blue;
     text-transform: capitalize;
+    position: relative;
     &:hover {
       text-decoration: none;
       color: white;
@@ -34,4 +35,26 @@
   p {
     margin-bottom: 2rem;
   }
+}
+
+
+a .tooltiptext {
+  visibility: hidden;
+  width: 120px;
+  background-color: white;
+  color: #414c7e;
+  text-align: center;
+  padding: 5px 0;
+  border: 1px #414c7e solid;
+  border-radius: 20px;
+  position: absolute;
+  z-index: 1;
+  bottom: -40px;
+  left: 50%; /* position the left edge of the element at the middle of the parent */
+  transform: translate(-50%, -50%);
+}
+
+/* Show the tooltip text when you mouse over the tooltip container */
+a:hover .tooltiptext {
+  visibility: visible;
 }

--- a/app/views/shared/_sources.html.erb
+++ b/app/views/shared/_sources.html.erb
@@ -1,8 +1,10 @@
 <% if @articles_found %>
   <div class="sources-found">
-    <p>Yay! We found <%= pluralize(@articles_found.keys.length, 'source') %> on <%= @topic %>. <%= "Please select one." if @articles_found.keys.length > 1 %></p>
+    <p>Yay! We found <%= pluralize(@articles_found.keys.length, 'source') %> on "<%= @topic %>". <%= "Please select one." if @articles_found.keys.length > 1 %></p>
     <% @articles_found.each do |source, article| %>
-      <%= link_to source, articles_path(article: article), method: 'post' %>
+      <%= link_to articles_path(article: article), method: 'post' do %>
+        <%= source %> <span class="tooltiptext"><%= article[:title] %></span>
+      <% end %>
     <% end %>
   </div>
 <% end %>


### PR DESCRIPTION
What's new 
![image](https://user-images.githubusercontent.com/8093761/111465325-3d2e1480-8722-11eb-94d4-eafa5c3b5670.png)

- Add tooltip **on hover** with article name to sources to account for wikipedia full text interpreter and search engine 