### PR TITLE
Handle api errors

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -13,7 +13,6 @@ class ArticlesController < ApplicationController
     @topic = params[:article][:q]
     # Check wikipedia
     @articles_found[:wikipedia] = top_article_wikipedia(params[:article][:q])
-    @articles_found[:test] = nil
     @articles_found.filter! { |_source, article| article.nil? }
     render 'pages/home'
   end
@@ -49,8 +48,7 @@ class ArticlesController < ApplicationController
       nil
     else
       response_content = JSON.parse(response)
-      # search didn't yield any result
-      if response_content[1] == []
+      if response_content[1] == [] # search didn't yield any result
         nil
       # search was successful
       else

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -45,13 +45,19 @@ class ArticlesController < ApplicationController
     parsed_query = query.split.map { |word| URI.escape(word) }.join('+')
     url = "https://en.wikipedia.org/w/api.php?action=opensearch&search=#{parsed_query}"
     response = RestClient.get(url)
-    if response.code != 200
+    if response.code != 200 # wikipedia's responses are almost always 200 (expect FATAL) but may contain errors or warnings
       nil
     else
       response_content = JSON.parse(response)
-      articles = response_content[1]
-      urls = response_content[3]
-      { title: articles.first, url: urls.first, source: "wikipedia.com" }
+      # search didn't yield any result
+      if response_content[1] == []
+        nil
+      # search was successful
+      else
+        articles = response_content[1]
+        urls = response_content[3]
+        { title: articles.first, url: urls.first, source: "wikipedia.com" }
+      end
     end
   end
 

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -13,6 +13,7 @@ class ArticlesController < ApplicationController
     @topic = params[:article][:q]
     # Check wikipedia
     @articles_found[:wikipedia] = top_article_wikipedia(params[:article][:q])
+    @articles_found.filter { |x| x.nil? }
     render 'pages/home'
   end
 
@@ -42,10 +43,15 @@ class ArticlesController < ApplicationController
   def top_article_wikipedia(query)
     parsed_query = query.split.map { |word| URI.escape(word) }.join('+')
     url = "https://en.wikipedia.org/w/api.php?action=opensearch&search=#{parsed_query}"
-    response = JSON.parse(RestClient.get(url))
-    articles = response[1]
-    urls = response[3]
-    { title: articles.first, url: urls.first, source: "wikipedia.com" }
+    response = RestClient.get(url)
+    if response.code != 200
+      nil
+    else
+      response_content = JSON.parse(response)
+      articles = response_content[1]
+      urls = response_content[3]
+      { title: articles.first, url: urls.first, source: "wikipedia.com" }
+    end
   end
 
   def article_params

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -13,7 +13,8 @@ class ArticlesController < ApplicationController
     @topic = params[:article][:q]
     # Check wikipedia
     @articles_found[:wikipedia] = top_article_wikipedia(params[:article][:q])
-    @articles_found.filter { |x| x.nil? }
+    @articles_found[:test] = nil
+    @articles_found.filter! { |_source, article| article.nil? }
     render 'pages/home'
   end
 

--- a/app/views/shared/_sources.html.erb
+++ b/app/views/shared/_sources.html.erb
@@ -2,8 +2,10 @@
   <div class="sources-found">
     <p>Yay! We found <%= pluralize(@articles_found.keys.length, 'source') %> on "<%= @topic %>". <%= "Please select one." if @articles_found.keys.length > 1 %></p>
     <% @articles_found.each do |source, article| %>
-      <%= link_to articles_path(article: article), method: 'post' do %>
-        <%= source %> <span class="tooltiptext"><%= article[:title] %></span>
+      <% if !article.nil? %>
+        <%= link_to articles_path(article: article), method: 'post' do %>
+          <%= source %> <span class="tooltiptext"><%= article[:title] %></span>
+        <% end %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/shared/_sources.html.erb
+++ b/app/views/shared/_sources.html.erb
@@ -1,12 +1,19 @@
 <% if @articles_found %>
-  <div class="sources-found">
-    <p>Yay! We found <%= pluralize(@articles_found.keys.length, 'source') %> on "<%= @topic %>". <%= "Please select one." if @articles_found.keys.length > 1 %></p>
-    <% @articles_found.each do |source, article| %>
-      <% if !article.nil? %>
-        <%= link_to articles_path(article: article), method: 'post' do %>
-          <%= source %> <span class="tooltiptext"><%= article[:title] %></span>
+  <% if @articles_found.count == 0 %>
+    <div class="sources-found">
+      <p>Sorry, we couldn't find any article on "<%= @topic %>". Feel free to search for something else.</p>
+    </div>
+  <% end %>
+  <% if @articles_found.count > 0 %>
+    <div class="sources-found">
+      <p>Yay! We found <%= pluralize(@articles_found.keys.length, 'source') %> on "<%= @topic %>". <%= "Please select one." if @articles_found.keys.length > 1 %></p>
+      <% @articles_found.each do |source, article| %>
+        <% if !article.nil? %>
+          <%= link_to articles_path(article: article), method: 'post' do %>
+            <%= source %> <span class="tooltiptext"><%= article[:title] %></span>
+          <% end %>
         <% end %>
       <% end %>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 <% end %>


### PR DESCRIPTION
What's new

- The article controller now handles wikipedia API error (!= 200) : the front behaves as if no article were found
- The article controller also handles "empty responses" (code 200, no result found) : a key value pair (source => nil) is created, then all pairs with nil value are filtered out. This avoids calling the API twice : the first time to check the content and the second time to store the article
![image](https://user-images.githubusercontent.com/8093761/111486628-f0553880-8737-11eb-9e7e-c6aae8e82692.png)
